### PR TITLE
Fix manuallogin enumeration type to match

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -8,7 +8,7 @@ namespace OptumHsaSaveItExport
 {
     public enum LoginType
     {
-        manualLogin,
+        manuallogin,
         basiclogin,
         fulllogin
     }


### PR DESCRIPTION
The parser will move the input to lowercase then attempt to match. For this to match the enum, the enum values have to be lowercase too.

Fixes #7 