### PR TITLE
Set UnhandledPromptBehavior to ignore

### DIFF
--- a/UiModel.cs
+++ b/UiModel.cs
@@ -25,6 +25,9 @@ namespace OptumHsaSaveItExport
 
         private UiModel()
         {
+            EdgeOptions options = new EdgeOptions();
+            options.UnhandledPromptBehavior = UnhandledPromptBehavior.Ignore;
+
             driver = new EdgeDriver();
             jsDriver = (IJavaScriptExecutor)driver;
         }


### PR DESCRIPTION
Any time the user attempts to navigate away from `fundingpremerawa.com`'s login screen, the website tries to send a prompt warning about unsaved information. However selenium doesn't know what to do with this prompt and will throw an `UnhandledAlertException`.

Set the options so that the exception doesn't get thrown.